### PR TITLE
Add view titles

### DIFF
--- a/SiskinIM/Base.lproj/Main.storyboard
+++ b/SiskinIM/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Chats List View Controller-->
+        <!--Chats-->
         <scene sceneID="hNz-n2-bh7">
             <objects>
                 <viewController storyboardIdentifier="ChatsListViewController" id="9pv-A4-QxB" customClass="ChatsListViewController" customModule="Siskin" customModuleProvider="target" sceneMemberID="viewController">
@@ -129,7 +129,7 @@
                         </prototypes>
                         <sections/>
                     </tableView>
-                    <navigationItem key="navigationItem" id="LKO-PG-RwH">
+                    <navigationItem key="navigationItem" title="Chats" id="LKO-PG-RwH">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="AHa-0l-wJt">
                             <connections>
                                 <action selector="addMucButtonClicked:" destination="9pv-A4-QxB" id="Fcb-M7-ynm"/>
@@ -447,7 +447,7 @@
                             <outlet property="delegate" destination="mps-t3-QBq" id="ZYI-Wf-ZtU"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" id="SEz-IM-IWL">
+                    <navigationItem key="navigationItem" title="Contacts" id="SEz-IM-IWL">
                         <barButtonItem key="rightBarButtonItem" systemItem="add" id="cDx-St-aU8">
                             <connections>
                                 <action selector="addBtnClicked:" destination="mps-t3-QBq" id="MNQ-v3-5LQ"/>
@@ -470,6 +470,12 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="2jh-uX-arh">
@@ -493,6 +499,12 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" systemColor="labelColor"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="wd7-5o-jHv">
@@ -526,6 +538,12 @@
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/SiskinIM/roster/RosterViewController.swift
+++ b/SiskinIM/roster/RosterViewController.swift
@@ -24,8 +24,6 @@ import UIKit
 import TigaseSwift
 
 class RosterViewController: AbstractRosterViewController, UIGestureRecognizerDelegate {
-
-    var availabilityFilterSelector: UISegmentedControl?;
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,10 +40,6 @@ class RosterViewController: AbstractRosterViewController, UIGestureRecognizerDel
         }
 
         navigationItem.leftBarButtonItem = self.editButtonItem
-        availabilityFilterSelector = UISegmentedControl(items: ["All", "Available"]);
-        navigationItem.titleView = availabilityFilterSelector;
-        availabilityFilterSelector?.selectedSegmentIndex = Settings.RosterAvailableOnly.getBool() ? 1 : 0;
-        availabilityFilterSelector?.addTarget(self, action: #selector(RosterViewController.availabilityFilterChanged), for: .valueChanged);
         
         setColors();
         updateNavBarColors();
@@ -88,21 +82,14 @@ class RosterViewController: AbstractRosterViewController, UIGestureRecognizerDel
     func updateNavBarColors() {
         if #available(iOS 13.0, *) {
             if self.traitCollection.userInterfaceStyle == .dark {
-                availabilityFilterSelector?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .selected);
-                availabilityFilterSelector?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .normal);
                 searchController.searchBar.setScopeBarButtonTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .selected)
                 searchController.searchBar.setScopeBarButtonTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .normal);
             } else {
-                availabilityFilterSelector?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor(named: "chatslistBackground")!], for: .selected);
-                availabilityFilterSelector?.setTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .normal);
                 searchController.searchBar.setScopeBarButtonTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor(named: "chatslistBackground")!], for: .selected)
                 searchController.searchBar.setScopeBarButtonTitleTextAttributes([NSAttributedString.Key.foregroundColor : UIColor.white], for: .normal);
             }
             searchController.searchBar.searchTextField.textColor = UIColor.white;
             searchController.searchBar.searchTextField.backgroundColor = (self.traitCollection.userInterfaceStyle != .dark ? UIColor.black : UIColor.white).withAlphaComponent(0.2);
-            DispatchQueue.main.async {
-                self.availabilityFilterSelector?.selectedSegmentIndex = Settings.RosterAvailableOnly.getBool() ? 1 : 0;
-            }
         }
     }
     
@@ -111,7 +98,7 @@ class RosterViewController: AbstractRosterViewController, UIGestureRecognizerDel
             return;
         }
         DispatchQueue.main.async {
-            self.initializeRosterProvider(availableOnly: (self.availabilityFilterSelector?.selectedSegmentIndex ?? 0) == 1, sortOrder: self.searchController.searchBar.selectedScopeButtonIndex == 0 ? .alphabetical : .availability);
+            self.initializeRosterProvider(availableOnly: false, sortOrder: self.searchController.searchBar.selectedScopeButtonIndex == 0 ? .alphabetical : .availability);
             self.tableView.reloadData();
         }
     }


### PR DESCRIPTION
Adds 'Chats' and 'Contacts' titles to the relevant screens. The availability filter was removed from the contacts view to accomplish this. I don't believe filtering by contact availability is very useful now that we have push notifications.

Screenshot:

![siskin-titles](https://user-images.githubusercontent.com/24315/102518562-5c68c780-4089-11eb-9ca9-fcebf01b29ae.png)
