### PR TITLE
Fix: Clipped chat attachment previews.

### DIFF
--- a/SiskinIM/conversation/AttachmentChatTableViewCell.swift
+++ b/SiskinIM/conversation/AttachmentChatTableViewCell.swift
@@ -107,8 +107,7 @@ class AttachmentChatTableViewCell: BaseChatTableViewCell, UIContextMenuInteracti
                 linkView.topAnchor.constraint(equalTo: self.customView.topAnchor, constant: 0),
                 linkView.bottomAnchor.constraint(equalTo: self.customView.bottomAnchor, constant: 0),
                 linkView.leadingAnchor.constraint(equalTo: self.customView.leadingAnchor, constant: 0),
-                linkView.trailingAnchor.constraint(equalTo: self.customView.trailingAnchor, constant: 0),
-                linkView.heightAnchor.constraint(lessThanOrEqualToConstant: 350)
+                linkView.trailingAnchor.constraint(lessThanOrEqualTo: self.customView.trailingAnchor, constant: 0)
             ]);
                 
             if isNew {


### PR DESCRIPTION
### Motivation
When sending images and video the previews are getting clipped, and some of the content is not visible.
This is mostly apparent on larger devices like an iPad or M1 Mac:
<img src="https://user-images.githubusercontent.com/28978251/169576517-9d8ae5da-4fb5-49e5-b39a-6fe250dc5dfe.jpeg" width=512px>

### Approach
Adjust constraints so that the size of the preview would be determined by the `intrinsicContentSize` instead.
This way we can leverage the logic Apple already has in place for determining the preview's dimensions.
The cat is now visible 🐈
<img src="https://user-images.githubusercontent.com/28978251/169577030-c1b61185-6c12-4723-b6e1-45626466e979.jpeg" width=512px>

### Testing
• Looked at few other message types and everything looked normal. Let me know, if there is something specific tis could break.